### PR TITLE
# EDIT - signData

### DIFF
--- a/app/src/main/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardViewModel.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardViewModel.java
@@ -194,7 +194,7 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
         // Generate Signature
         String signature = null;
         try {
-            signature = keystoreUtil.signData(sigTarget);
+            signature = keystoreUtil.signData(sigTarget.getBytes());
         } catch (KeyStoreException | UnrecoverableEntryException | NoSuchAlgorithmException
                 | SignatureException | InvalidKeyException | CertificateException | IOException e) {
             throw new AuthUtilException(AuthUtilException.AuthErr.SIGNING_ERROR);
@@ -362,7 +362,7 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
             outputStream.write(sigHgt);
             outputStream.write(Base64.decode(msgRequestSignature.getTransaction(), Base64.NO_WRAP));
 
-            signature = keystoreUtil.signData(outputStream.toString());
+            signature = keystoreUtil.signData(outputStream.toByteArray());
             outputStream.close();
 
             logMerger1.postValue("Signature generated!");

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/util/KeystoreUtil.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/util/KeystoreUtil.java
@@ -210,11 +210,9 @@ public class KeystoreUtil {
      *
      * @return A string encoding of the data signature generated
      */
-    public String signData(String inputStr)
+    public String signData(byte[] data)
             throws KeyStoreException, UnrecoverableEntryException, NoSuchAlgorithmException,
             InvalidKeyException, SignatureException, IOException, CertificateException {
-        byte[] data = inputStr.getBytes();
-
         KeyStore ks = KeyStore.getInstance(KEYSTORE_PROVIDER_ANDROID_KEYSTORE);
         ks.load(null);
 


### PR DESCRIPTION
#30 PR을 잘못 Merge하여 다시 생성한 PR....

## 수정사항
- 종전의 코드에서는 `signData`에 string을 넘겨주고 있었는데, string을 다시 bytes로 변환해서 서명을 하고 있기 때문에 string이 아닌 bytes로 넘겨주는게 낫다.
- 특히 OutputStream의 경우 1. bytes[] -> 2. string(toString) -> 3. bytes[](getBytes) 형변환을 하게 되면 1번과 3번의 크기의 차이가 발생한다.
- signData를 bytes로 받도록 수정

## WARNING
- 머지할때 base 브랜치를 develop으로 변경해야 합니다. (signing2 브랜치가 develop에 머지되었다는 가정하에)
