### PR TITLE
EDIT - DH키 교환시 Signature 생성 및 검증 방법 수정

### DIFF
--- a/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthCertUtil.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthCertUtil.java
@@ -250,12 +250,11 @@ public class AuthCertUtil {
      * @param certification The certification stored in the Android Keystore
      * @return A boolean value telling you whether the signature is valid or not.
      */
-    public boolean verifyData(String input, String signatureStr, String certification)
+    public boolean verifyData(byte[] input, String signatureStr, String certification)
             throws CertificateException, NoSuchProviderException, NoSuchAlgorithmException,
             InvalidKeyException, SignatureException {
         X509Certificate certificate = stringToCertificate(certification);
 
-        byte[] data = input.getBytes();
         byte[] signature;
 
         // Make sure the signature string exists.  If not, bail out, nothing to do.
@@ -282,7 +281,7 @@ public class AuthCertUtil {
 
         // Verify the data.
         s.initVerify(certificate.getPublicKey());
-        s.update(data);
+        s.update(input);
         return s.verify(signature);
     }
 

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthGeneralUtil.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthGeneralUtil.java
@@ -1,11 +1,16 @@
 package com.gruutnetworks.gruutsigner.util;
 
+import android.util.Base64;
+import org.spongycastle.util.encoders.Hex;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Calendar;
 
 public class AuthGeneralUtil {
 
-    private static final int MAX_NONCE_LENGTH = 64;
+    private static final int MAX_NONCE_LENGTH = 32;
 
     /**
      * get UNIX timestamp of current time
@@ -15,19 +20,28 @@ public class AuthGeneralUtil {
     }
 
     /**
-     * get 64 byte random string array
+     * 32 byte Nonce를 Base64로 인코딩하여 반환
      *
-     * @return nonce value
+     * @return Base64 encoded nonce value
      */
     public static String getNonce() {
-        String candidateChars = "ABCDEFGHIZKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
+        String candidateChars = "abcdef1234567890";
 
         SecureRandom generator = new SecureRandom();
-        StringBuilder randomStringBuilder = new StringBuilder();
-        for (int i = 0; i < MAX_NONCE_LENGTH; i++) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        for (int i = 0; i < MAX_NONCE_LENGTH * 2; i++) {
             char tempChar = candidateChars.charAt(generator.nextInt(candidateChars.length()));
-            randomStringBuilder.append(tempChar);
+            outputStream.write(tempChar);
         }
-        return randomStringBuilder.toString();
+
+        byte[] hexDecodedNonce = Hex.decode(outputStream.toByteArray());
+        String base64EncodedNonce = new String(Base64.encode(hexDecodedNonce, Base64.NO_WRAP));
+        try {
+            outputStream.close();
+        } catch (IOException e) {
+            return null;
+        }
+
+        return base64EncodedNonce;
     }
 }


### PR DESCRIPTION
## 수정 이유
* GE5. Data Structure의 6.2 Signature 문서에 맞게 Sign을 생성하고 검증해야한다.
* 현재는 String concat으로 signature를 만들고 검증함.

## 수정 내용 
* String concat으로 sig 생성&검증하던 부분을 바이트 처리하는 것으로 수정
    * nonce는 32byte
    * timestamp는 8byte
    * x, y값은 32byte
* 이에 맞게 verifyData 메소드의 파라미터도 byte array로 수정
* 문서에 맞게 Nonce를 생성하도록 수정
    1. 64 byte HEX byte array 생성
    2. HEX decoding하여 32 byte array에 넣음
    3. 32 byte array를 Base64 encoding하여 반환