### PR TITLE
# EDIT - signer id의 데이터 타입 수정

### DIFF
--- a/app/src/main/java/com/gruutnetworks/gruutsigner/model/SignUpResponse.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/model/SignUpResponse.java
@@ -9,7 +9,7 @@ public class SignUpResponse {
     @SerializedName("message")
     private String message;
     @SerializedName("nid")
-    private int nid;
+    private String nid;
     @SerializedName("pem")
     private String pem;
 
@@ -17,31 +17,16 @@ public class SignUpResponse {
         return code;
     }
 
-    public void setCode(int code) {
-        this.code = code;
-    }
-
     public String getMessage() {
         return message;
     }
 
-    public void setMessage(String message) {
-        this.message = message;
-    }
-
-    public int getNid() {
+    public String getNid() {
         return nid;
-    }
-
-    public void setNid(int nid) {
-        this.nid = nid;
     }
 
     public String getPem() {
         return pem;
     }
 
-    public void setPem(String pem) {
-        this.pem = pem;
-    }
 }

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardViewModel.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardViewModel.java
@@ -5,7 +5,6 @@ import android.arch.lifecycle.*;
 import android.os.AsyncTask;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
-import android.util.Base64;
 import android.util.Log;
 import com.google.protobuf.ByteString;
 import com.gruutnetworks.gruutsigner.*;
@@ -21,11 +20,8 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-import org.spongycastle.util.encoders.Hex;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
@@ -61,7 +57,7 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
         this.authCertUtil = AuthCertUtil.getInstance();
         this.authHmacUtil = AuthHmacUtil.getInstance();
         this.preferenceUtil = PreferenceUtil.getInstance(application.getApplicationContext());
-        this.sender = Integer.toString(preferenceUtil.getInt(PreferenceUtil.Key.SID_INT));
+        this.sender = preferenceUtil.getString(PreferenceUtil.Key.SID_STR);
 
         if (!NetworkUtil.isConnected(application.getApplicationContext())) {
             SnackbarMessage snackbarMessage = new SnackbarMessage();
@@ -133,7 +129,7 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
         logMerger1.postValue("START requestJoin...");
 
         PackMsgJoin packMsgJoin = new PackMsgJoin(
-                Base64.encodeToString(sender.getBytes(), Base64.NO_WRAP),
+                sender,
                 AuthGeneralUtil.getTimestamp(),
                 GruutConfigs.ver,
                 GruutConfigs.localChainId
@@ -214,7 +210,7 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
         }
 
         PackMsgResponse1 msgResponse1 = new PackMsgResponse1(
-                Base64.encodeToString(sender.getBytes(), Base64.NO_WRAP),
+                sender,
                 time,
                 cert,
                 signerNonce,
@@ -284,7 +280,7 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
         preferenceUtil.put(PreferenceUtil.Key.HMAC_STR, new String(hmacKey));
 
         PackMsgSuccess msgSuccess = new PackMsgSuccess(
-                Base64.encodeToString(sender.getBytes(), Base64.NO_WRAP),
+                sender,
                 AuthGeneralUtil.getTimestamp(),
                 true
         );
@@ -360,7 +356,7 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
         String time = AuthGeneralUtil.getTimestamp();
         String signature;
         try {
-            signature = authCertUtil.generateSupportSignature(sender,time, msgRequestSignature.getmID(), GruutConfigs.localChainId,
+            signature = authCertUtil.generateSupportSignature(sender, time, msgRequestSignature.getmID(), GruutConfigs.localChainId,
                     msgRequestSignature.getBlockHeight(), msgRequestSignature.getTransaction());
             logMerger1.postValue("Signature generated!");
         } catch (Exception e) {
@@ -368,7 +364,7 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
         }
 
         PackMsgSignature msgSignature = new PackMsgSignature(
-                Base64.encodeToString(sender.getBytes(), Base64.NO_WRAP),
+                sender,
                 time,
                 signature
         );

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/ui/signup/SignUpViewModel.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/ui/signup/SignUpViewModel.java
@@ -40,7 +40,7 @@ public class SignUpViewModel extends AndroidViewModel implements LifecycleObserv
         super(application);
         this.authCertUtil = AuthCertUtil.getInstance();
         this.preferenceUtil = PreferenceUtil.getInstance(application.getApplicationContext());
-        
+
         // Get Certificate issued by GA
         try {
             String cert = authCertUtil.getCert(SecurityConstants.Alias.GRUUT_AUTH);
@@ -83,7 +83,7 @@ public class SignUpViewModel extends AndroidViewModel implements LifecycleObserv
 
                             if (storeCertificate(response.body().getPem())) {
                                 canJoin.postValue(true);
-                                preferenceUtil.put(PreferenceUtil.Key.SID_INT, response.body().getNid());
+                                preferenceUtil.put(PreferenceUtil.Key.SID_STR, response.body().getNid());
                                 navigateToDashboard.call();
                             } else {
                                 snackbarMessage.setValue(R.string.sign_up_error_cert);

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthCertUtil.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthCertUtil.java
@@ -199,12 +199,12 @@ public class AuthCertUtil {
     /**
      * Generate a signature for MSG_RESPONSE1
      *
-     * @param mNonce    merger's nonce
-     * @param sNonce    signer's nonce
-     * @param x         signer's dh x hex value
-     * @param y         singer's dh y hex value
-     * @param time      timestamp
-     * @return  signature string
+     * @param mNonce merger's nonce
+     * @param sNonce signer's nonce
+     * @param x      signer's dh x hex value
+     * @param y      singer's dh y hex value
+     * @param time   timestamp
+     * @return signature string
      */
     public String signMsgResponse1(String mNonce, String sNonce, String x, String y, String time)
             throws IOException, CertificateException, InvalidKeyException, NoSuchAlgorithmException,
@@ -260,29 +260,28 @@ public class AuthCertUtil {
     /**
      * MSG_REQ_SSIG에 대한 지지서명 생성
      *
-     * @param sender    signer의 id. int value...?
-     * @param time      timestamp
-     * @param mId       요청한 merger의 id
-     * @param cId       local chain id
-     * @param hgt       block height
-     * @param tx        transaction root
+     * @param sender signer id          (Base64)
+     * @param time   timestamp
+     * @param mId    요청한 merger의 id (Base64)
+     * @param cId    local chain id     (Base64)
+     * @param hgt    block height
+     * @param tx     transaction root   (Base64)
      * @return support signature string
      */
     public String generateSupportSignature(String sender, String time, String mId, String cId, String hgt, String tx)
             throws IOException, CertificateException, InvalidKeyException, NoSuchAlgorithmException,
             KeyStoreException, SignatureException, UnrecoverableEntryException {
 
-        byte[] sigSender = ByteBuffer.allocate(8).putLong(Integer.parseInt(sender)).array();
         byte[] sigTime = ByteBuffer.allocate(8).putLong(Integer.parseInt(time)).array();
         byte[] sigHgt = ByteBuffer.allocate(8).putLong(Integer.parseInt(hgt)).array();
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        outputStream.write(sigSender);                          // 64 bit
-        outputStream.write(sigTime);                            // 64 bit
-        outputStream.write(Base64.decode(mId, Base64.NO_WRAP)); // 64 bit
-        outputStream.write(Base64.decode(cId, Base64.NO_WRAP)); // 64 bit
-        outputStream.write(sigHgt);                             // 64 bit
-        outputStream.write(Base64.decode(tx, Base64.NO_WRAP));  // 256 bit
+        outputStream.write(Base64.decode(sender, Base64.NO_WRAP));  // 64 bit
+        outputStream.write(sigTime);                                // 64 bit
+        outputStream.write(Base64.decode(mId, Base64.NO_WRAP));     // 64 bit
+        outputStream.write(Base64.decode(cId, Base64.NO_WRAP));     // 64 bit
+        outputStream.write(sigHgt);                                 // 64 bit
+        outputStream.write(Base64.decode(tx, Base64.NO_WRAP));      // 256 bit
 
         String signature = authCertUtil.sign(outputStream.toByteArray());
         outputStream.close();

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/util/PreferenceUtil.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/util/PreferenceUtil.java
@@ -14,7 +14,7 @@ public class PreferenceUtil {
      * Enum representing your setting names or key for your setting.
      */
     public enum Key {
-        SID_INT, HMAC_STR, IP_STR, PORT_STR
+        SID_STR, HMAC_STR, IP_STR, PORT_STR
     }
 
     private PreferenceUtil(Context context) {


### PR DESCRIPTION
# 수정 이유
* GA로부터 수신 받는 nid가 Base64 String으로 변경됨에 따라 이를 저장하고 사용하는 부분을 수정함

# 수정 내용
* SharedPreference에 sid를 저장할 때, base 64 string으로 바로 저장
* signature 생성하는 부분에서는 pref에 저장된 base64 string을 decode하여 바이트로 처리
* 송신 메세지에서 json에 sender가 들어가는 부분은 모두 pref에 저장된 base64 string을 바로 보내도록 수정