### PR TITLE
GEN-49 서명한 블록의 chain id와 블록 높이를 저장

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,8 @@ idea {
 }
 
 dependencies {
-    def grpcVersion = '1.16.1'
+    def grpc_version = '1.16.1'
+    def room_version = "1.1.1"
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
@@ -91,9 +92,9 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'android.arch.lifecycle:extensions:1.1.1'
     // grpc-java
-    implementation "io.grpc:grpc-okhttp:$grpcVersion"
-    implementation "io.grpc:grpc-protobuf-lite:$grpcVersion"
-    implementation "io.grpc:grpc-stub:$grpcVersion"
+    implementation "io.grpc:grpc-okhttp:$grpc_version"
+    implementation "io.grpc:grpc-protobuf-lite:$grpc_version"
+    implementation "io.grpc:grpc-stub:$grpc_version"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     // LZ4 for compression
     implementation 'org.lz4:lz4-java:1.5.0'
@@ -102,12 +103,16 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
     // crypto
     implementation 'com.madgag.spongycastle:prov:1.58.0.0'
+    // room
+    implementation "android.arch.persistence.room:runtime:$room_version"
+    annotationProcessor "android.arch.persistence.room:compiler:$room_version"
 
     testImplementation 'junit:junit:4.12'
     testImplementation "org.powermock:powermock-module-junit4:1.7.4"
     testImplementation "org.powermock:powermock-api-mockito2:1.7.4"
     testImplementation 'org.robolectric:robolectric:4.0.2'
     testImplementation 'androidx.test:core:1.0.0'
+    testImplementation "android.arch.persistence.room:testing:$room_version"
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/model/SignedBlock.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/model/SignedBlock.java
@@ -1,0 +1,33 @@
+package com.gruutnetworks.gruutsigner.model;
+
+import android.arch.persistence.room.ColumnInfo;
+import android.arch.persistence.room.Entity;
+import android.support.annotation.NonNull;
+
+import javax.annotation.Nullable;
+
+@Entity(primaryKeys = {"chain_id", "block_hgt"})
+public class SignedBlock {
+    @NonNull
+    @ColumnInfo(name = "chain_id")
+    private String chainId;
+    @NonNull
+    @ColumnInfo(name = "block_hgt")
+    private String blockHeight;
+
+    public String getChainId() {
+        return chainId;
+    }
+
+    public void setChainId(String chainId) {
+        this.chainId = chainId;
+    }
+
+    public String getBlockHeight() {
+        return blockHeight;
+    }
+
+    public void setBlockHeight(String blockHeight) {
+        this.blockHeight = blockHeight;
+    }
+}

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/model/SignedBlockDao.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/model/SignedBlockDao.java
@@ -1,0 +1,17 @@
+package com.gruutnetworks.gruutsigner.model;
+
+import android.arch.persistence.room.Dao;
+import android.arch.persistence.room.Insert;
+import android.arch.persistence.room.OnConflictStrategy;
+import android.arch.persistence.room.Query;
+
+@Dao
+public interface SignedBlockDao {
+
+    @Query("SELECT * FROM signedblock WHERE chain_id = (:chainId) AND block_hgt = (:blockHeight)")
+    SignedBlock findByPrimaryKey(String chainId, String blockHeight);
+
+    @Insert(onConflict = OnConflictStrategy.FAIL)
+    void insertAll(SignedBlock... blocks);
+
+}

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardViewModel.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardViewModel.java
@@ -42,6 +42,7 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
     private AuthCertUtil authCertUtil;
     private AuthHmacUtil authHmacUtil;
     private PreferenceUtil preferenceUtil;
+    private SignedBlockDao blockDao;
 
     private ManagedChannel channel1;
     private ManagedChannel channel2;
@@ -58,6 +59,8 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
         this.authHmacUtil = AuthHmacUtil.getInstance();
         this.preferenceUtil = PreferenceUtil.getInstance(application.getApplicationContext());
         this.sender = preferenceUtil.getString(PreferenceUtil.Key.SID_STR);
+
+        blockDao = AppDatabase.getDatabase(application).blockDao();
 
         if (!NetworkUtil.isConnected(application.getApplicationContext())) {
             SnackbarMessage snackbarMessage = new SnackbarMessage();
@@ -356,6 +359,11 @@ public class DashboardViewModel extends AndroidViewModel implements LifecycleObs
         String time = AuthGeneralUtil.getTimestamp();
         String signature;
         try {
+            SignedBlock block = new SignedBlock();
+            block.setChainId(msgRequestSignature.getChainId());
+            block.setBlockHeight(msgRequestSignature.getBlockHeight());
+            blockDao.insertAll();
+
             signature = authCertUtil.generateSupportSignature(sender, time, msgRequestSignature.getmID(), GruutConfigs.localChainId,
                     msgRequestSignature.getBlockHeight(), msgRequestSignature.getTransaction());
             logMerger1.postValue("Signature generated!");

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/util/AppDatabase.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/util/AppDatabase.java
@@ -1,0 +1,30 @@
+package com.gruutnetworks.gruutsigner.util;
+
+import android.arch.persistence.room.Database;
+import android.arch.persistence.room.Room;
+import android.arch.persistence.room.RoomDatabase;
+import android.content.Context;
+import com.gruutnetworks.gruutsigner.model.SignedBlock;
+import com.gruutnetworks.gruutsigner.model.SignedBlockDao;
+
+@Database(entities = {SignedBlock.class}, version = 1, exportSchema = false)
+public abstract class AppDatabase extends RoomDatabase {
+
+    private static AppDatabase INSTANCE;
+
+    public abstract SignedBlockDao blockDao();
+
+    public static AppDatabase getDatabase(final Context context) {
+        if (INSTANCE == null) {
+            synchronized (AppDatabase.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = Room.databaseBuilder(context.getApplicationContext(),
+                            AppDatabase.class, "app_database")
+                            .fallbackToDestructiveMigration()
+                            .build();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+}

--- a/app/src/test/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardViewModelTest.java
+++ b/app/src/test/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardViewModelTest.java
@@ -1,20 +1,46 @@
 package com.gruutnetworks.gruutsigner.ui.dashboard;
 
+import android.arch.persistence.room.Room;
+import android.content.Context;
+import android.database.sqlite.SQLiteConstraintException;
 import android.util.Base64;
+import androidx.test.core.app.ApplicationProvider;
 import com.gruutnetworks.gruutsigner.RobolectricTest;
+import com.gruutnetworks.gruutsigner.model.SignedBlock;
+import com.gruutnetworks.gruutsigner.model.SignedBlockDao;
+import com.gruutnetworks.gruutsigner.util.AppDatabase;
 import com.gruutnetworks.gruutsigner.util.AuthGeneralUtil;
+import junit.framework.Assert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @PrepareForTest({Base64.class})
 public class DashboardViewModelTest extends RobolectricTest {
 
+    private SignedBlockDao blockDao;
+    private AppDatabase mDb;
+
     @Before
     public void setUp() throws Exception {
+        Context context = ApplicationProvider.getApplicationContext();
+        mDb = Room.inMemoryDatabaseBuilder(context, AppDatabase.class)
+                .allowMainThreadQueries()
+                .build();
+        blockDao = mDb.blockDao();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mDb.close();
     }
 
     @Test
@@ -36,6 +62,26 @@ public class DashboardViewModelTest extends RobolectricTest {
             outputStream.close();
         } catch (Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void writeBlockAndReadInList() throws Exception {
+        SignedBlock block = new SignedBlock();
+        block.setBlockHeight("1");
+        block.setChainId("R0VOVEVTVDE=");
+
+        blockDao.insertAll(block);
+
+        SignedBlock searchedBlock = blockDao.findByPrimaryKey("R0VOVEVTVDE=", "1");
+        assertThat(searchedBlock.getChainId(), is(block.getChainId()));
+        assertThat(searchedBlock.getBlockHeight(), is(block.getBlockHeight()));
+
+        try {
+            blockDao.insertAll(block);
+            Assert.fail("SQLiteConstraintException");
+        } catch (SQLiteConstraintException e) {
+            // expected
         }
     }
 }


### PR DESCRIPTION
* 내부 DB에 서명한 블록의 chain id와 블록 height를 저장할 수 있도록 함.
* chain_id와 block_hgt를 결합하여 primary key로 사용.
* 이미 있는 블록 정보라면, fail이 떠서 exception 처리하도록