### PR TITLE
GEN-183: # BUGFIX - certification tag concat #time 10m #finish

### DIFF
--- a/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthCertUtil.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthCertUtil.java
@@ -193,7 +193,10 @@ public class AuthCertUtil {
             // 저장 된 certificate 없을 경우 null 반환
             return null;
         }
-        return new String(Base64.encode(certificate.getEncoded(), Base64.NO_WRAP));
+
+        return "-----BEGIN CERTIFICATE-----\n" +
+                new String(Base64.encode(certificate.getEncoded(), Base64.NO_WRAP))
+                + "\n-----END CERTIFICATE-----";
     }
 
     /**


### PR DESCRIPTION
# 버그
* java security의 X509 certificate class가 pem을 핸들링하는 방식이 달라서 생긴 문제
1. Signer는 GA로부터 받은 pem cert에서 TAG를 지우고 X509 cert 형식으로 keystore에 저장
2. Signer는 merger에게 cert를 보낼 때, keystore에서 꺼낸 X509 cert형식에 TAG를 씌우지 않고 보냈더니 문제

# 수정 사항
* keystore에서 꺼낸 X509Cert에 TAG를 씌워서 string을 만듦.

# TODO
* SpongyCastle의 pem object 클래스등을 활용하면 string concat이 아닌 예쁜 모습으로도 가능할듯(나중에 수정 예정)