### PR TITLE
GEN-204: # EDIT - 죽은 채널의 온기를 담고있는 버그 수정

### DIFF
--- a/app/src/main/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardFragment.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/ui/dashboard/DashboardFragment.java
@@ -55,6 +55,7 @@ public class DashboardFragment extends Fragment implements SettingFragment.Setti
             SettingFragment settingFragment = SettingFragment.newInstance(DashboardViewModel.MergerNum.MERGER_1);
             settingFragment.setTargetFragment(this, 0);
             settingFragment.show(getFragmentManager(), "fragment_address_setting");
+            waitForAutoRefresh.removeCallbacksAndMessages(null);
         });
         viewModel.getErrorMerger1().observe(this, err -> {
             if (err) {
@@ -71,6 +72,7 @@ public class DashboardFragment extends Fragment implements SettingFragment.Setti
             SettingFragment settingFragment = SettingFragment.newInstance(DashboardViewModel.MergerNum.MERGER_2);
             settingFragment.setTargetFragment(this, 0);
             settingFragment.show(getFragmentManager(), "fragment_address_setting");
+            waitForAutoRefresh.removeCallbacksAndMessages(null);
         });
         viewModel.getErrorMerger2().observe(this, err -> {
             if (err) {
@@ -81,9 +83,14 @@ public class DashboardFragment extends Fragment implements SettingFragment.Setti
     }
 
     @Override
-    public void onDestroy() {
+    public void onPause() {
         waitForAutoRefresh.removeCallbacksAndMessages(null);
         viewModel.onCleared();
+        super.onPause();
+    }
+
+    @Override
+    public void onDestroy() {
         super.onDestroy();
     }
 


### PR DESCRIPTION
# 수정 이유
* 채널이 종료되었을 때, 에러로 인해서 종료된 건지 혹은 Merger가 죽어서 종료된 건지 구분하는 코드가 없었음
* 이 구분이 안되다 보니 직전에 죽은 채널의 메세지가 현재 통신에 로그로 찍히고, UI에도 영향을 미침

# 수정 내용
* 채널을 종료할 때는 즉각적으로 닫도록
* 채널이  닫힌 상태에서의 에러와 그렇지 않을 때를 구분하여 로그를 남김
(보통 채널이 닫힌 상태에서의 로그는 남지 않아야 함)