### PR TITLE
GEN-149: # EDIT - ECDSA 서명을 사용하도록 변경

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ android:
         - 'android-sdk-license-.+'
         - 'google-gdk-license-.+'
 script:
-    - ./gradlew --no-daemon --parallel assembleDebug lintDebug test
+    - ./gradlew --no-daemon --parallel --info assembleDebug lintDebug test
 deploy:
     provider: script
     skip_cleanup: true

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/ui/signup/SignUpViewModel.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/ui/signup/SignUpViewModel.java
@@ -134,7 +134,7 @@ public class SignUpViewModel extends AndroidViewModel implements LifecycleObserv
     private String generateCsr() {
         try {
             if (!authCertUtil.isKeyPairExist()) {
-                authCertUtil.generateRsaKeys();
+                authCertUtil.generateKeyPair();
             }
             return authCertUtil.generateCsr();
         } catch (Exception e) {

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthCertUtil.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/util/AuthCertUtil.java
@@ -10,6 +10,7 @@ import org.spongycastle.asn1.pkcs.Attribute;
 import org.spongycastle.asn1.pkcs.CertificationRequest;
 import org.spongycastle.asn1.pkcs.CertificationRequestInfo;
 import org.spongycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.spongycastle.asn1.sec.SECObjectIdentifiers;
 import org.spongycastle.asn1.x500.X500Name;
 import org.spongycastle.asn1.x500.X500NameBuilder;
 import org.spongycastle.asn1.x500.style.BCStyle;
@@ -34,12 +35,12 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 import static com.gruutnetworks.gruutsigner.util.SecurityConstants.Alias.GRUUT_AUTH;
-import static com.gruutnetworks.gruutsigner.util.SecurityConstants.KEYSTORE_PROVIDER_ANDROID_KEYSTORE;
-import static com.gruutnetworks.gruutsigner.util.SecurityConstants.SIGNATURE_SHA256withRSA;
+import static com.gruutnetworks.gruutsigner.util.SecurityConstants.*;
 
 public class AuthCertUtil {
 
@@ -67,7 +68,7 @@ public class AuthCertUtil {
      *
      * @return generated Key pair's public key
      */
-    public PublicKey generateRsaKeys()
+    public PublicKey generateKeyPair()
             throws NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException {
         // Create a start and end time, for the validity range of the key pair that's about to be generated.
         Calendar start = new GregorianCalendar();
@@ -75,13 +76,13 @@ public class AuthCertUtil {
         end.add(Calendar.YEAR, 30);
 
         KeyPairGenerator kpGenerator = KeyPairGenerator
-                .getInstance(KeyProperties.KEY_ALGORITHM_RSA, KEYSTORE_PROVIDER_ANDROID_KEYSTORE);
+                .getInstance(KeyProperties.KEY_ALGORITHM_EC, KEYSTORE_PROVIDER_ANDROID_KEYSTORE);
 
         AlgorithmParameterSpec spec = new KeyGenParameterSpec
                 .Builder(mAlias, KeyProperties.PURPOSE_SIGN | KeyProperties.PURPOSE_VERIFY)
+                .setAlgorithmParameterSpec(new ECGenParameterSpec(CURVE_SECP256R1))
                 .setCertificateSubject(new X500Principal("CN=" + mAlias))
                 .setDigests(KeyProperties.DIGEST_SHA256)
-                .setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1)
                 .setCertificateSerialNumber(BigInteger.valueOf(1337))
                 .setCertificateNotBefore(start.getTime())
                 .setCertificateNotAfter(end.getTime())
@@ -113,7 +114,7 @@ public class AuthCertUtil {
         CertificationRequestInfo requestInfo =
                 new CertificationRequestInfo(nameBuilder.build(), publicKeyInfo, null);
 
-        AlgorithmIdentifier signatureAi = new AlgorithmIdentifier(PKCSObjectIdentifiers.sha256WithRSAEncryption);
+        AlgorithmIdentifier signatureAi = new AlgorithmIdentifier(SECObjectIdentifiers.secp256r1);
         Attribute attribute = new Attribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, new DERSet());
 
         CertificationRequest certificationRequest
@@ -328,7 +329,7 @@ public class AuthCertUtil {
         // This class doesn't actually represent the signature,
         // just the engine for creating/verifying signatures, using
         // the specified algorithm.
-        Signature s = Signature.getInstance(SIGNATURE_SHA256withRSA);
+        Signature s = Signature.getInstance(SHA256withECDSA);
 
         // Initialize Signature using specified private key
         s.initSign(((KeyStore.PrivateKeyEntry) entry).getPrivateKey());
@@ -376,7 +377,7 @@ public class AuthCertUtil {
         // This class doesn't actually represent the signature,
         // just the engine for creating/verifying signatures, using
         // the specified algorithm.
-        Signature s = Signature.getInstance(SIGNATURE_SHA256withRSA);
+        Signature s = Signature.getInstance(SHA256withECDSA);
 
         // Verify the data.
         s.initVerify(certificate.getPublicKey());
@@ -435,7 +436,7 @@ public class AuthCertUtil {
         // This class doesn't actually represent the signature,
         // just the engine for creating/verifying signatures, using
         // the specified algorithm.
-        Signature s = Signature.getInstance(SIGNATURE_SHA256withRSA);
+        Signature s = Signature.getInstance(SHA256withECDSA);
 
         // Verify the data.
         s.initVerify(ks.getCertificate(mAlias).getPublicKey());

--- a/app/src/main/java/com/gruutnetworks/gruutsigner/util/SecurityConstants.java
+++ b/app/src/main/java/com/gruutnetworks/gruutsigner/util/SecurityConstants.java
@@ -8,6 +8,7 @@ public interface SecurityConstants {
     String TYPE_HMAC = "HmacSHA256";
 
     String SIGNATURE_SHA256withRSA = "SHA256withRSA";
+    String SHA256withECDSA = "SHA256withECDSA";
 
     String CURVE_SECP256R1 = "secp256r1";
 

--- a/app/src/test/java/com/gruutnetworks/gruutsigner/util/AuthCertUtilTest.java
+++ b/app/src/test/java/com/gruutnetworks/gruutsigner/util/AuthCertUtilTest.java
@@ -2,6 +2,7 @@ package com.gruutnetworks.gruutsigner.util;
 
 import android.util.Base64;
 import com.gruutnetworks.gruutsigner.RobolectricTest;
+import junit.framework.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -9,6 +10,9 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.lang.reflect.Method;
 import java.security.cert.X509Certificate;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 @PrepareForTest({Base64.class})
 public class AuthCertUtilTest extends RobolectricTest {
@@ -32,25 +36,35 @@ public class AuthCertUtilTest extends RobolectricTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         authCertUtil = AuthCertUtil.getInstance();
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
     }
 
     @Test
     public void stringToCertificate() {
-        String certPem = "-----BEGIN CERTIFICATE-----\n" +
-                "MIIBFTCBvKADAgECAgIFOTAKBggqhkjOPQQDAjAUMRIwEAYDVQQDDAlTRUxGX0NFUlQwHhcN" +
-                "MTgxMjI4MDIwOTM3WhcNNDgxMjI4MDIwOTM3WjAUMRIwEAYDVQQDDAlTRUxGX0NFUlQwWTAT" +
-                "BgcqhkjOPQIBBggqhkjOPQMBBwNCAAT/+CWhnJTsFS/1h8o+ZUbfBcoRhIGXPXJhFJ/0JyWW" +
-                "b/7kDiINzTjkKX+phoB3gCnKiArypjFNZTvshJq7/Mm8MAoGCCqGSM49BAMCA0gAMEUCIFzb" +
-                "JoTGBKDsPQ7v3gmqGe1aKNUwlHahO12UOeliOGZoAiEA7D3OQiscVKonr1eLli6tgyeXJqQH" +
-                "3x6iUgtrNJcTHb8=\n" +
-                "-----END CERTIFICATE-----";
+        String certPem = "-----BEGIN CERTIFICATE-----\r\n" +
+                "MIIBFTCBvKADAgECAgIFOTAKBggqhkjOPQQDAjAUMRIwEAYDVQQDDAlTRUxGX0NF\r\n" +
+                "UlQwHhcNMTgxMjI4MDIwOTM3WhcNNDgxMjI4MDIwOTM3WjAUMRIwEAYDVQQDDAlT\r\n" +
+                "RUxGX0NFUlQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT/+CWhnJTsFS/1h8o+\r\n" +
+                "ZUbfBcoRhIGXPXJhFJ/0JyWWb/7kDiINzTjkKX+phoB3gCnKiArypjFNZTvshJq7\r\n" +
+                "/Mm8MAoGCCqGSM49BAMCA0gAMEUCIFzbJoTGBKDsPQ7v3gmqGe1aKNUwlHahO12U\r\n" +
+                "OeliOGZoAiEA7D3OQiscVKonr1eLli6tgyeXJqQH3x6iUgtrNJcTHb8=\r\n-----END CERTIFICATE-----\r\n";
 
-        AuthCertUtilTest.invokeMethod(AuthCertUtil.class, "stringToCertificate", X509Certificate.class, certPem);
+        X509Certificate cert = AuthCertUtilTest.invokeMethod(AuthCertUtil.class,
+                "stringToCertificate",
+                X509Certificate.class, certPem);
+
+        try {
+            String pemStr = AuthCertUtilTest.invokeMethod(AuthCertUtil.class,
+                    "bytesToPemString", String.class, "CERTIFICATE", cert.getEncoded());
+
+            assertThat(pemStr, is(certPem));
+        } catch (Exception e) {
+            Assert.fail("Exception: " + e);
+        }
     }
 }

--- a/app/src/test/java/com/gruutnetworks/gruutsigner/util/AuthCertUtilTest.java
+++ b/app/src/test/java/com/gruutnetworks/gruutsigner/util/AuthCertUtilTest.java
@@ -1,0 +1,56 @@
+package com.gruutnetworks.gruutsigner.util;
+
+import android.util.Base64;
+import com.gruutnetworks.gruutsigner.RobolectricTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import java.lang.reflect.Method;
+import java.security.cert.X509Certificate;
+
+@PrepareForTest({Base64.class})
+public class AuthCertUtilTest extends RobolectricTest {
+
+    private AuthCertUtil authCertUtil;
+
+    @SuppressWarnings("unchecked")
+    public static <T> T invokeMethod(Class<?> clazz, String methodName, Class<T> returnType, Object... args) {
+        Class<?>[] parameters = new Class<?>[args.length];
+        for (int i = 0; i < args.length; i++) {
+            parameters[i] = args[i].getClass();
+        }
+        try {
+            Object obj = clazz.newInstance();
+            Method method = obj.getClass().getDeclaredMethod(methodName, parameters);
+            method.setAccessible(true);
+            return (T) method.invoke(obj, args);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        authCertUtil = AuthCertUtil.getInstance();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void stringToCertificate() {
+        String certPem = "-----BEGIN CERTIFICATE-----\n" +
+                "MIIBFTCBvKADAgECAgIFOTAKBggqhkjOPQQDAjAUMRIwEAYDVQQDDAlTRUxGX0NFUlQwHhcN" +
+                "MTgxMjI4MDIwOTM3WhcNNDgxMjI4MDIwOTM3WjAUMRIwEAYDVQQDDAlTRUxGX0NFUlQwWTAT" +
+                "BgcqhkjOPQIBBggqhkjOPQMBBwNCAAT/+CWhnJTsFS/1h8o+ZUbfBcoRhIGXPXJhFJ/0JyWW" +
+                "b/7kDiINzTjkKX+phoB3gCnKiArypjFNZTvshJq7/Mm8MAoGCCqGSM49BAMCA0gAMEUCIFzb" +
+                "JoTGBKDsPQ7v3gmqGe1aKNUwlHahO12UOeliOGZoAiEA7D3OQiscVKonr1eLli6tgyeXJqQH" +
+                "3x6iUgtrNJcTHb8=\n" +
+                "-----END CERTIFICATE-----";
+
+        AuthCertUtilTest.invokeMethod(AuthCertUtil.class, "stringToCertificate", X509Certificate.class, certPem);
+    }
+}

--- a/app/src/test/java/com/gruutnetworks/gruutsigner/util/AuthCertUtilTest.java
+++ b/app/src/test/java/com/gruutnetworks/gruutsigner/util/AuthCertUtilTest.java
@@ -46,13 +46,15 @@ public class AuthCertUtilTest extends RobolectricTest {
 
     @Test
     public void stringToCertificate() {
-        String certPem = "-----BEGIN CERTIFICATE-----\r\n" +
-                "MIIBFTCBvKADAgECAgIFOTAKBggqhkjOPQQDAjAUMRIwEAYDVQQDDAlTRUxGX0NF\r\n" +
-                "UlQwHhcNMTgxMjI4MDIwOTM3WhcNNDgxMjI4MDIwOTM3WjAUMRIwEAYDVQQDDAlT\r\n" +
-                "RUxGX0NFUlQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT/+CWhnJTsFS/1h8o+\r\n" +
-                "ZUbfBcoRhIGXPXJhFJ/0JyWWb/7kDiINzTjkKX+phoB3gCnKiArypjFNZTvshJq7\r\n" +
-                "/Mm8MAoGCCqGSM49BAMCA0gAMEUCIFzbJoTGBKDsPQ7v3gmqGe1aKNUwlHahO12U\r\n" +
-                "OeliOGZoAiEA7D3OQiscVKonr1eLli6tgyeXJqQH3x6iUgtrNJcTHb8=\r\n-----END CERTIFICATE-----\r\n";
+        String certPem = "-----BEGIN CERTIFICATE-----\n" +
+                "MIIBFTCBvKADAgECAgIFOTAKBggqhkjOPQQDAjAUMRIwEAYDVQQDDAlTRUxGX0NF\n" +
+                "UlQwHhcNMTgxMjI4MDIwOTM3WhcNNDgxMjI4MDIwOTM3WjAUMRIwEAYDVQQDDAlT\n" +
+                "RUxGX0NFUlQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT/+CWhnJTsFS/1h8o+\n" +
+                "ZUbfBcoRhIGXPXJhFJ/0JyWWb/7kDiINzTjkKX+phoB3gCnKiArypjFNZTvshJq7\n" +
+                "/Mm8MAoGCCqGSM49BAMCA0gAMEUCIFzbJoTGBKDsPQ7v3gmqGe1aKNUwlHahO12U\n" +
+                "OeliOGZoAiEA7D3OQiscVKonr1eLli6tgyeXJqQH3x6iUgtrNJcTHb8=\n-----END CERTIFICATE-----\n";
+
+        String expected = certPem.replaceAll("\\n|\\r\\n", System.getProperty("line.separator"));
 
         X509Certificate cert = AuthCertUtilTest.invokeMethod(AuthCertUtil.class,
                 "stringToCertificate",
@@ -62,7 +64,7 @@ public class AuthCertUtilTest extends RobolectricTest {
             String pemStr = AuthCertUtilTest.invokeMethod(AuthCertUtil.class,
                     "bytesToPemString", String.class, "CERTIFICATE", cert.getEncoded());
 
-            assertThat(pemStr, is(certPem));
+            assertThat(pemStr, is(expected));
         } catch (Exception e) {
             Assert.fail("Exception: " + e);
         }

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -3,7 +3,7 @@ export DEPLOY_BRANCH="$TRAVIS_BRANCH"
 NEWLINE="%0A"
 SLACK_KEY="$SLACK_BOT_TOKEN"
 SLACK_TEXT=":socks: 테스트 실행 파일을 가져왔어요[\`$DEPLOY_BRANCH\`] :socks:
-\`https://github.com/${TRAVIS_REPO_SLUG}tree/$DEPLOY_BRANCH\`
+\`https://github.com/${TRAVIS_REPO_SLUG}/tree/$DEPLOY_BRANCH\`
 ${TRAVIS_COMMIT_MESSAGE:-none}"
 
 curl https://slack.com/api/files.upload \


### PR DESCRIPTION
# 수정 이유
* 현재 merger와 signer의 서명은 RSA를 사용하고 있습니다.
* RSA는 장점이 있지만, 저장 공간을 많이 차지합니다. 따라서 수많은 블록체인에서는 ECC 기반의 서명 기법을 사용합니다.
* ECDSA는 PKI 시스템에 사용할 수 있으므로 ECDSA를 사용할 필요성이 있습니다.

# 수정 사항
* 키 생성 시 ECDSA 키를 생성하도록
* CSR 생성 시 ECDSA를 기반으로 생성
* Sign/Verify 시 에도 ECDSA 사용
* Pem Tag를 일일히 String concat으로 처리하던 부분을 SpongyCastle의 PemObject와 PemWriter를 이용하는 것으로 변경

# TODO
* Merger와 GA가 ECDSA로 변경되었을  때, 같이 테스트가 필요합니다.
* 위의 PemWriter를 사용하는 과정에서 해당 시스템의 Line seperator를 사용하여 pem을 생성하므로 이 부분에 대한 테스트도 필요합니다.